### PR TITLE
Move unnecessary deps to extras.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setup(
     packages=['smartleia'],
     package_dir={"": "."},
     package_data={"smartleia": ["*.csv", "*.ipynb"]},
-    install_requires=['dephell==0.*,>=0.8.3', 'pyserial==3.*,>=3.4.0', 'pytest==5.*,>=5.2.0', 'pytest-csv==2.*,>=2.0.2'],
-    extras_require={"dev": ["black==19.*,>=19.10.0.b0", "bump2version==1.*,>=1.0.0", "coverage==5.*,>=5.1.0", "flake8==3.*,>=3.7.9", "ipython==7.*,>=7.14.0", "mypy==0.*,>=0.770.0", "nbsphinx==0.*,>=0.7.0", "pandoc==1.*,>=1.0.2", "pre-commit==2.*,>=2.3.0", "pylint==2.*,>=2.5.2", "pytest-runner==5.*,>=5.2.0", "recommonmark==0.*,>=0.6.0", "sphinx==3.*,>=3.0.0", "sphinx-autodoc-typehints==1.*,>=1.10.3", "sphinx-rtd-theme==0.*,>=0.5.0", "sphinxcontrib.spelling==5.*,>=5.0.0", "sphinxcontrib.wavedrom==2.*,>=2.1.0"]},
+    install_requires=['pyserial==3.*,>=3.4.0'],
+    extras_require={
+        "dev": ["dephell==0.*,>=0.8.3", "black==19.*,>=19.10.0.b0", "bump2version==1.*,>=1.0.0", "coverage==5.*,>=5.1.0", "flake8==3.*,>=3.7.9", "ipython==7.*,>=7.14.0", "mypy==0.*,>=0.770.0", "nbsphinx==0.*,>=0.7.0", "pandoc==1.*,>=1.0.2", "pre-commit==2.*,>=2.3.0", "pylint==2.*,>=2.5.2", "pytest-runner==5.*,>=5.2.0", "recommonmark==0.*,>=0.6.0", "sphinx==3.*,>=3.0.0", "sphinx-autodoc-typehints==1.*,>=1.10.3", "sphinx-rtd-theme==0.*,>=0.5.0", "sphinxcontrib.spelling==5.*,>=5.0.0", "sphinxcontrib.wavedrom==2.*,>=2.1.0"],
+        "test": ['pytest==5.*,>=5.2.0', 'pytest-csv==2.*,>=2.0.2']
+    },
 )


### PR DESCRIPTION
This PR moves the `dephell` dependency to "dev" requires as it is not needed to use the library.
Similarly, pytest dependencies are moved to a new "test" extra as they are not needed to use the library and
are polluting dependencies unnecessarily.

This is a significant usability improvement as dephell is [deprecated and unmaintained](https://github.com/dephell/dephell) and also its installation in a current modern Python venv fails due to issues in outdated dependencies (m2r package, same error as https://github.com/jupyter/notebook/issues/6531).